### PR TITLE
Speed up CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ node_js:
 - '6'
 - '5'
 - '4'
-install:
-- npm install --only=dev
+cache:
+  directories:
+    - node_modules
 notifications:
   slack:
     secure: "BDNxGvbnIyqGhup6lOInE/75OAIV4+cdq2a1XR/Lb3OhTHPcIou3AhBIrj0iD9+EyKWtSMEMpa8fbCd0/lARSr8jxz7RoSR6xxsGJjZ5eX9xSyvtec3y/zXfocBIaPJKJStrh/r01QPIbjOtnI3biYFZXvef/j91gO4qHOqOGDRv523ogdWJC/e69pbNl99glvCH8UXYVIvESMLJymMUizttOHdVo4051xPRqLRye+9UQLv5JXFh2f9p073OjKct3yMXysCrOClcpzEwQDAOo6o0QeOdcQN4m7lhwpbHBadTuZ8m2fEBD00ZbxLyXr2hsO1QZGRULoI9TqgeapoKpbXtpI/UDvKBo4HLKuO3z7XeWUqJsffzYaRTTCs8jcQHGL6nmfr4XmU098p6vRjo7+c+Alfr5C2+YLhhircGRRhvm36FJyBj5BoLne8TVt96EiIlDgzsg98DzmT8p4hq8CvWm45M4vlInHRBOOSiCS7G+p6kAVR92zxZybCJBD9W5NoV8UPvfC3mQqs/LvGCUCSKxNDMD15rNY+a6v/LNDsmXabUBTGxnuyETc4axyu0Iu5gAjQKnBpqdnMNCAcSqxKFy1wYt7VgnMy0XxDLeYqwNBpvw7Yr0vmfDxFvdBLCboGK3jiHpvZagwc77Xdy5usts4LnLvTtGJjc19LdT58="

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
 - '6'
 - '5'
 - '4'
+install:
+- npm install --only=dev
 notifications:
   slack:
     secure: "BDNxGvbnIyqGhup6lOInE/75OAIV4+cdq2a1XR/Lb3OhTHPcIou3AhBIrj0iD9+EyKWtSMEMpa8fbCd0/lARSr8jxz7RoSR6xxsGJjZ5eX9xSyvtec3y/zXfocBIaPJKJStrh/r01QPIbjOtnI3biYFZXvef/j91gO4qHOqOGDRv523ogdWJC/e69pbNl99glvCH8UXYVIvESMLJymMUizttOHdVo4051xPRqLRye+9UQLv5JXFh2f9p073OjKct3yMXysCrOClcpzEwQDAOo6o0QeOdcQN4m7lhwpbHBadTuZ8m2fEBD00ZbxLyXr2hsO1QZGRULoI9TqgeapoKpbXtpI/UDvKBo4HLKuO3z7XeWUqJsffzYaRTTCs8jcQHGL6nmfr4XmU098p6vRjo7+c+Alfr5C2+YLhhircGRRhvm36FJyBj5BoLne8TVt96EiIlDgzsg98DzmT8p4hq8CvWm45M4vlInHRBOOSiCS7G+p6kAVR92zxZybCJBD9W5NoV8UPvfC3mQqs/LvGCUCSKxNDMD15rNY+a6v/LNDsmXabUBTGxnuyETc4axyu0Iu5gAjQKnBpqdnMNCAcSqxKFy1wYt7VgnMy0XxDLeYqwNBpvw7Yr0vmfDxFvdBLCboGK3jiHpvZagwc77Xdy5usts4LnLvTtGJjc19LdT58="

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/carloscuesta/starterkit/issues"
   },
   "homepage": "https://github.com/carloscuesta/starterkit#readme",
-  "devDependencies": {
+  "dependencies": {
     "browser-sync": "^2.17.0",
     "critical": "^0.8.0",
     "flexboxgrid": "^6.3.1",
@@ -47,7 +47,9 @@
     "gulp-surge": "^0.1.0",
     "gulp-uglify": "^2.0.0",
     "gulp-uncss": "^1.0.6",
-    "vinyl-ftp": "^0.5.0",
+    "vinyl-ftp": "^0.5.0"
+  },
+  "devDependencies": {
     "xo": "^0.17.0"
   }
 }


### PR DESCRIPTION
See #50 instead of not installing ./node_modules (this will throw linter issues requires not found and this is a good check) just cache the node_modules directory.
